### PR TITLE
Update from URuntimeMeshComponent to URuntimeMeshComponentStatic

### DIFF
--- a/src/TerrainComponent.cpp
+++ b/src/TerrainComponent.cpp
@@ -40,14 +40,17 @@ void UTerrainComponent::GenerateVertices() {
 }
 
 void UTerrainComponent::GenerateMesh() {
-	RuntimeMesh->CreateMeshSection(0,
+	RuntimeMesh->CreateSectionFromComponents(0, // LOD index
+		0, // Section Index
+		0, // Material slot
 		Vertices,
 		Triangles,
 		Normals,
 		UV,
 		VertexColors,
 		Tangents,
-		true, EUpdateFrequency::Infrequent);
+		ERuntimeMeshUpdateFrequency::Infrequent,
+		true); // create collision. This adds significant cost
 }
 
 void UTerrainComponent::GenerateTriangles() {
@@ -104,7 +107,7 @@ void UTerrainComponent::BeginPlay()
 {
 	Super::BeginPlay();
 	Noise = Cast<UPerlinNoiseComponent>(GetOwner()->GetComponentByClass(UPerlinNoiseComponent::StaticClass()));
-	RuntimeMesh = Cast<URuntimeMeshComponent>(GetOwner()->GetComponentByClass(URuntimeMeshComponent::StaticClass()));
+	RuntimeMesh = Cast<URuntimeMeshComponentStatic>(GetOwner()->GetComponentByClass(URuntimeMeshComponentStatic::StaticClass()));
 	// ...
 	
 }

--- a/src/TerrainComponent.h
+++ b/src/TerrainComponent.h
@@ -6,7 +6,7 @@
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
 #include "PerlinNoiseComponent.h"
-#include "RuntimeMeshComponent.h"
+#include "Components/RuntimeMeshComponentStatic.h"
 #include "Components/ActorComponent.h"
 #include "TerrainComponent.generated.h"
 
@@ -33,7 +33,7 @@ public:
 	float NoiseOutputScale = 2000; // Making this bigger will scale the terrain's height
 
 	UPerlinNoiseComponent* Noise;
-	URuntimeMeshComponent* RuntimeMesh;
+	URuntimeMeshComponentStatic* RuntimeMesh;
 
 	void GenerateVertices();
 	void GenerateTriangles();


### PR DESCRIPTION
Hey!
First of all thank you for creating this repo and a blog article. Really helped me!
[RuntimeMeshComponent](https://github.com/TriAxis-Games/RuntimeMeshComponent) was updated and now instead of `URuntimeMeshComponent` they use `URuntimeMeshComponentStatic` for `CreateSectionFromComponents`    

--- 
![image](https://user-images.githubusercontent.com/37109805/103463463-cdb4a580-4d2c-11eb-8ec5-e79fbde0b801.png)
